### PR TITLE
Update broken URL to zlib-1.2.13 to point to GitHub

### DIFF
--- a/build-x86.sh
+++ b/build-x86.sh
@@ -347,7 +347,7 @@ fi
 # build zlib
 # -----------------------------------------------------------------------------
 if [ ! -f "$INSTALL_PATH"/lib/libz.a ]; then
-  wget -nc https://zlib.net/zlib-1.2.13.tar.gz
+  wget -nc https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz
   tar -xf zlib-1.2.13.tar.gz
   cd zlib-1.2.13 || exit
   CC=$WGET_GCC CFLAGS="-m32 -march=i686" ./configure --static --prefix="$INSTALL_PATH"

--- a/build.sh
+++ b/build.sh
@@ -347,7 +347,7 @@ fi
 # build zlib
 # -----------------------------------------------------------------------------
 if [ ! -f "$INSTALL_PATH"/lib/libz.a ]; then
-  wget -nc https://zlib.net/zlib-1.2.13.tar.gz
+  wget -nc https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz
   tar -xf zlib-1.2.13.tar.gz
   cd zlib-1.2.13 || exit
   CC=$WGET_GCC ./configure --64 --static --prefix="$INSTALL_PATH"


### PR DESCRIPTION
The link to https://zlib.net/zlib-1.2.13.tar.gz was returning a 404. This pull request updates the URL to point to this specific release on GitHub.